### PR TITLE
fixes eslint errors due to no-useless-escape

### DIFF
--- a/raspberry_pi/petscii.js
+++ b/raspberry_pi/petscii.js
@@ -5,6 +5,7 @@ function to(input) {
   const sanitizedInput = input
     .replace(/\r/g, '')
     .replace(/\n/g, '\r')
+    // eslint-disable-next-line no-useless-escape
     .replace(/[^A-Za-z 0-9 \.,\?""!@#\$%\^&\*\(\)-_=\+;:<>\/\\\|\}\{\[\]`~\r]*/g, '')
     .replace(/_/g, '-')
     .replace(/`/g, '\x27');  // '`' in petscii


### PR DESCRIPTION
I had a failure while running `npm test` as per the installation instructions for the raspberry_pi node app.

```
ankur:raspberry_pi/ (master) $ npm test                              [11:35:11]

> raspi_c64_slack_client_proxy@1.0.0 test /Users/ankur/Developer/c64-slack-client/raspberry_pi
> eslint . && mocha tests/


/Users/ankur/Developer/c64-slack-client/raspberry_pi/petscii.js
  8:28  error  Unnecessary escape character: \.  no-useless-escape
  8:31  error  Unnecessary escape character: \?  no-useless-escape
  8:38  error  Unnecessary escape character: \$  no-useless-escape
  8:41  error  Unnecessary escape character: \^  no-useless-escape
  8:44  error  Unnecessary escape character: \*  no-useless-escape
  8:46  error  Unnecessary escape character: \(  no-useless-escape
  8:48  error  Unnecessary escape character: \)  no-useless-escape
  8:53  error  Unnecessary escape character: \+  no-useless-escape
  8:59  error  Unnecessary escape character: \/  no-useless-escape
  8:63  error  Unnecessary escape character: \|  no-useless-escape
  8:65  error  Unnecessary escape character: \}  no-useless-escape
  8:67  error  Unnecessary escape character: \{  no-useless-escape
  8:69  error  Unnecessary escape character: \[  no-useless-escape

✖ 13 problems (13 errors, 0 warnings)

npm ERR! Test failed.  See above for more details.
```

This PR fixes the issue but just ignoring the rule on the one line.