### PR TITLE
Remove extraneous backslashes

### DIFF
--- a/raspberry_pi/petscii.js
+++ b/raspberry_pi/petscii.js
@@ -5,7 +5,7 @@ function to(input) {
   const sanitizedInput = input
     .replace(/\r/g, '')
     .replace(/\n/g, '\r')
-    .replace(/[^A-Za-z 0-9 \.,\?""!@#\$%\^&\*\(\)-_=\+;:<>\/\\\|\}\{\[\]`~\r]*/g, '')
+    .replace(/[^A-Za-z 0-9 .,?""!@#$%^&*()-_=+;:<>/\\|}{[\]`~\r]*/g, '')
     .replace(/_/g, '-')
     .replace(/`/g, '\x27');  // '`' in petscii
 


### PR DESCRIPTION
Under eslint 3.11.1,  petscii.js fails due to extraneous backslashes in the regex. Inside character classes, only backslash and `]` need to be escaped. 