### PR TITLE
Allow uppercase from C64

### DIFF
--- a/raspberry_pi/app.js
+++ b/raspberry_pi/app.js
@@ -120,7 +120,7 @@ c64Channel.on('commandReceived', (command, data) => {
       break;
     }
     case rpcMethods.SEND_MESSAGE: {
-      const msgBody = petscii.from(data.toString('ascii'));
+      const msgBody = petscii.from(data.toString('latin1'));
       if (msgBody.length === 0) {
         break;
       }

--- a/raspberry_pi/petscii.js
+++ b/raspberry_pi/petscii.js
@@ -5,7 +5,7 @@ function to(input) {
   const sanitizedInput = input
     .replace(/\r/g, '')
     .replace(/\n/g, '\r')
-    .replace(/[^A-Za-z 0-9 .,?""!@#$%^&*()-_=+;:<>/\\|}{[\]`~\r]*/g, '')
+    .replace(/[^A-Za-z\xc1-\xda 0-9.,?'"!@#$%^&*()-_=+;:<>/\\|}{[\]`~\r]*/g, '')
     .replace(/_/g, '-')
     .replace(/`/g, '\x27');  // '`' in petscii
 
@@ -16,6 +16,8 @@ function to(input) {
       petsciiString += String.fromCharCode(ascii + 32);
     } else if (ascii >= 97 && ascii <= 122) {
       petsciiString += String.fromCharCode(ascii - 32);
+    } else if (ascii >= 193 && ascii <= 218) {
+      petsciiString += String.fromCharCode(ascii - 128);
     } else {
       petsciiString += sanitizedInput[i];
     }


### PR DESCRIPTION
Capital letters appear twice in shifted PETSCII, once in the ASCII lowercase range (0x61-0x7A) and again at the the range corresponding to uppercase with the high bit set (0xC1-0xDA). The normal keyboard input routines result in the latter codes, which the Node app was stripping the high-bit from by forcing ASCII on the buffer data, effectively downcasing them. This commit allows uppercase characters typed on the C64 to make it through to Slack.

It was also stripping apostrophes in the sanitization step, due to an apparent typo (double-quote was included in the negated character class twice, apostrophe not at all).