### PR TITLE
Fix timestamp format

### DIFF
--- a/raspberry_pi/app.js
+++ b/raspberry_pi/app.js
@@ -120,7 +120,7 @@ c64Channel.on('commandReceived', (command, data) => {
       break;
     }
     case rpcMethods.SEND_MESSAGE: {
-      const msgBody = petscii.from(data.toString('ascii'));
+      const msgBody = petscii.from(data.toString('latin1'));
       if (msgBody.length === 0) {
         break;
       }

--- a/raspberry_pi/app.js
+++ b/raspberry_pi/app.js
@@ -54,7 +54,7 @@ function writeSlackMessageToC64(message) {
       userString = `${user.name} [bot]`;
     }
     const msgDate = new Date(parseFloat(message.ts) * 1000);
-    let headerText = util.format('%s %d:%d ',
+    let headerText = util.format('%s %s:%s ',
       userString,
       _.padStart(String(msgDate.getHours()), 2, '0'),
       _.padStart(String(msgDate.getMinutes()), 2, '0'));

--- a/raspberry_pi/petscii.js
+++ b/raspberry_pi/petscii.js
@@ -5,7 +5,7 @@ function to(input) {
   const sanitizedInput = input
     .replace(/\r/g, '')
     .replace(/\n/g, '\r')
-    .replace(/[^A-Za-z 0-9 .,?""!@#$%^&*()-_=+;:<>/\\|}{[\]`~\r]*/g, '')
+    .replace(/[^A-Za-z\xc1-\xda 0-9.,?'"!@#$%^&*()-_=+;:<>/\\|}{[\]`~\r]*/g, '')
     .replace(/_/g, '-')
     .replace(/`/g, '\x27');  // '`' in petscii
 
@@ -16,6 +16,8 @@ function to(input) {
       petsciiString += String.fromCharCode(ascii + 32);
     } else if (ascii >= 97 && ascii <= 122) {
       petsciiString += String.fromCharCode(ascii - 32);
+    } else if (ascii >= 193 && ascii <= 218) {
+      petsciiString += String.fromCharCode(ascii - 128);
     } else {
       petsciiString += sanitizedInput[i];
     }


### PR DESCRIPTION
After padding the timestamp fields out to two digits, they are passed to `util.format()` with `%d` format directives, meaning they get parsed back to numbers and the padding is thrown away. If `util.format` supported the full printf syntax, could just use `%02d` and not bother with the `pad` calls at all. But since it doesn't, use `%s` so that the preformatted strings are passed through unscathed.